### PR TITLE
Show Invalid option message

### DIFF
--- a/bin/envswitch
+++ b/bin/envswitch
@@ -51,4 +51,10 @@ program
     index.envSwitcher.showStatus();
   });
 
+program
+  .on('*', function () {
+    console.error('Invalid option: %s\nSee $envswitch --help for a list of available options.', program.args.join(' '));
+    process.exit(1);
+  });
+
 program.parse(process.argv);


### PR DESCRIPTION
If we run with `envswitch hoge`, it show like the message.

```bash
Invalid option: hoge
See $envswitch --help for a list of available options.
```