### PR TITLE
-e is not needed

### DIFF
--- a/bin/envswitch
+++ b/bin/envswitch
@@ -16,7 +16,7 @@ program
 
 program
   .command('init')
-  .description('initialize your project. eg., $envswitch init -e dev')
+  .description('initialize your project. eg., $envswitch init dev')
   .action((envname) => {
     if (typeof envname === 'object') {
       index.envSwitcher.initialize();


### PR DESCRIPTION
if using `e` option, the error occurred
```
> envswitch init -e dev
error: unknown option `-e'
```